### PR TITLE
Add keypoint handling for CVLFace

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ preprocess = Compose([
     Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
 ])
 image = preprocess(Image.open('face.jpg')).unsqueeze(0).to(device)
-aligned, *_ = aligner(image)
+aligned, keypoints, *_ = aligner(image)
 
 model = LeWrapper(backbone)
-heatmap = model.compute_legrad(image=aligned, text_embedding=None)
+heatmap = model.compute_legrad(image=aligned, text_embedding=None, keypoints=keypoints)
 visualize(image=image, heatmaps=heatmap)
 ```
  

--- a/cvlface_playground.py
+++ b/cvlface_playground.py
@@ -25,11 +25,11 @@ preprocess = Compose([
     Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
 ])
 image = preprocess(Image.open(img_path).convert('RGB')).unsqueeze(0).to(device)
-aligned, *_ = aligner(image)
+aligned, keypoints, *_ = aligner(image)
 
 # 3. Equip backbone with LeGrad and compute explanation
 model = LeWrapper(backbone)
-heatmap = model.compute_legrad(image=aligned, text_embedding=None)
+heatmap = model.compute_legrad(image=aligned, text_embedding=None, keypoints=keypoints)
 
 # 4. Visualize result
 visualize(image=image, heatmaps=heatmap)


### PR DESCRIPTION
## Summary
- add optional keypoints argument to `compute_legrad` and `compute_legrad_cvlface`
- forward keypoints from the aligner in example script and README

## Testing
- `python -m py_compile legrad/wrapper.py cvlface_playground.py app.py playground.py legrad/utils.py`
- `pip install open_clip_torch==2.23.0 -q` *(fails: Operation cancelled by user)*
- `python cvlface_playground.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6867cffcc8a48328ab25df7905a674d4