### PR TITLE
Fix gradient extraction for CVLFace

### DIFF
--- a/legrad/wrapper.py
+++ b/legrad/wrapper.py
@@ -332,6 +332,12 @@ class LeWrapper(nn.Module):
         else:
             target_embedding = F.normalize(target_embedding, dim=-1)
 
+        # ensure intermediate features are recorded with gradients
+        if keypoints is not None:
+            _ = self.forward(image, keypoints=keypoints)
+        else:
+            _ = self.forward(image)
+
         blocks_list = list(dict(self.visual.blocks.named_children()).values())
         w = h = int(math.sqrt(self.visual.num_patches))
 


### PR DESCRIPTION
## Summary
- recompute CVLFace backbone forward pass without torch.no_grad to ensure attention maps require gradients

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6867d898104483288b4b204188414ba3